### PR TITLE
Simplify documentation

### DIFF
--- a/docs/primitives/cryptographic-hashes.rst
+++ b/docs/primitives/cryptographic-hashes.rst
@@ -1,8 +1,30 @@
 Message Digests
 ====================
 
+.. class:: cryptography.primitives.hashes.BaseHash
+
+   Abstract base class that implements a common interface for
+   all hash algorithms that follow here
+
+    .. method:: update(string)
+
+        :param bytes string: The bytes you wish to hash.
+
+    .. method:: copy()
+
+        :return: a new instance of this object with a
+         copied internal state.
+
+    .. method:: digest()
+
+        :return bytes: The message digest as bytes.
+
+    .. method:: hexdigest()
+
+        :return str: The message digest as hex.
+
 SHA-1
-~~~~~~~
+~~~~~
 
 .. attention::
 
@@ -14,132 +36,47 @@ SHA-1
     SHA-1 is a cryptographic hash function standardized by NIST. It has a
     160-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
-
 SHA-2 Family
-~~~~~~~
+~~~~~~~~~~~~
 
 .. class:: cryptography.primitives.hashes.SHA224()
 
     SHA-224 is a cryptographic hash function from the SHA-2 family and
     standardized by NIST. It has a 224-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
 .. class:: cryptography.primitives.hashes.SHA256()
 
     SHA-256 is a cryptographic hash function from the SHA-2 family and
     standardized by NIST. It has a 256-bit message digest.
-
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
 
 .. class:: cryptography.primitives.hashes.SHA384()
 
     SHA-384 is a cryptographic hash function from the SHA-2 family and
     standardized by NIST. It has a 384-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
 .. class:: cryptography.primitives.hashes.SHA512()
 
     SHA-512 is a cryptographic hash function from the SHA-2 family and
     standardized by NIST. It has a 512-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
 RIPEMD160
-~~~~~~~
+~~~~~~~~~
 
 .. class:: cryptography.primitives.hashes.RIPEMD160()
 
     RIPEMD160 is a cryptographic hash function that is part of ISO/IEC
     10118-3:2004. It has a 160-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
 Whirlpool
-~~~~~~~
+~~~~~~~~~
 
 .. class:: cryptography.primitives.hashes.Whirlpool()
 
     Whirlpool is a cryptographic hash function that is part of ISO/IEC
     10118-3:2004. It has a 512-bit message digest.
 
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.
-
 MD5
-~~~~~~~
+~~~
 
 .. warning::
 
@@ -150,15 +87,3 @@ MD5
 
     MD5 is a deprecated cryptographic hash function. It has a 160-bit message
     digest and has practical known collision attacks.
-
-    .. method:: update(string)
-
-        :param bytes string: The bytes you wish to hash.
-
-    .. method:: digest()
-
-        :return bytes: The message digest as bytes.
-
-    .. method:: hexdigest()
-
-        :return str: The message digest as hex.


### PR DESCRIPTION
Write out documentation for the base class and remove from the others.

Also, sphinx doesn't like the ~'s not being the same length as the header text
