### PR TITLE
Limit RSA-OAEP padding to SHA-1 and SHA-2 algorithms in supported openssl

### DIFF
--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -578,27 +578,46 @@ class Backend(object):
         userdata = _PasswordUserdata(password=password)
         return _pem_password_cb, userdata
 
-
     def _get_mgf1_supported_padding_hashes(backend):
         # Verified test Vectors for OAEP only cover SHA-1 and SHA-2 currently
         # with OpenSSL >= 1.0.2.
         if backend._lib.OpenSSL_version_num() >= 0x10002001:
             _oaep_supported_padding_algorithms = (
-                hashes.SHA224, hashes.SHA256,
-                hashes.SHA384, hashes.SHA512
+                hashes.SHA1,
+                hashes.SHA224,
+                hashes.SHA256,
+                hashes.SHA384,
+                hashes.SHA512
             )
         else:
             _oaep_supported_padding_algorithms = ( hashes.SHA1, )
 
         return _oaep_supported_padding_algorithms
 
-
     def _mgf1_hash_supported(self, algorithm):
-        if (self._lib.Cryptography_HAS_MGF1_MD and
-            isinstance(algorithm, self._get_mgf1_supported_padding_hashes())):
-                return self.hash_supported(algorithm)
+        if self._lib.Cryptography_HAS_MGF1_MD:
+            return (isinstance(algorithm,
+                self._get_mgf1_supported_padding_hashes()) and
+                self.hash_supported(algorithm))
         else:
             return isinstance(algorithm, hashes.SHA1)
+
+    def _mgf1_hash_combination_supported(self, mgf_algo, algo):
+        if (self._mgf1_hash_supported(mgf_algo) and
+            self._mgf1_hash_supported(algo)):
+
+            # The same algorithm for both is always suppoted (SHA-1 or SHA-2)
+            if type(mgf_algo) is type(algo):
+                return True
+
+            # SHA-1 with SHA-2 combinations are not supported however:
+            if (isinstance(mgf_algo, hashes.SHA1) or
+                isinstance(algo, hashes.SHA1)):
+                return False
+
+            return True
+
+        return False
 
     def rsa_padding_supported(self, padding):
         if isinstance(padding, PKCS1v15):
@@ -606,13 +625,11 @@ class Backend(object):
         elif isinstance(padding, PSS) and isinstance(padding._mgf, MGF1):
             return self._mgf1_hash_supported(padding._mgf._algorithm)
         elif isinstance(padding, OAEP) and isinstance(padding._mgf, MGF1):
-            if self._lib.OpenSSL_version_num() >= 0x10002001:
-                return (
-                    self._mgf1_hash_supported(padding._mgf._algorithm) and
-                    self._mgf1_hash_supported(padding._algorithm)
-                )
-            else:
-                return isinstance(padding._mgf._algorithm, hashes.SHA1)
+            return (
+                self._mgf1_hash_combination_supported(
+                    padding._mgf._algorithm,
+                    padding._algorithm)
+            )
         else:
             return False
 

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -594,16 +594,6 @@ class Backend(object):
 
         return _oaep_supported_padding_algorithms
 
-    def _oaep_mgf1_hash_supported(self, algorithm):
-        if self._lib.Cryptography_HAS_MGF1_MD:
-            return (
-                isinstance(algorithm,
-                    self._get_oaep_supported_padding_algorithms()) and
-                self.hash_supported(algorithm)
-            )
-        else:
-            return isinstance(algorithm, hashes.SHA1)
-
     def _oaep_hash_supported(self, algorithm):
         return (
             isinstance(algorithm,
@@ -624,7 +614,7 @@ class Backend(object):
             return self._pss_mgf1_hash_supported(padding._mgf._algorithm)
         elif isinstance(padding, OAEP) and isinstance(padding._mgf, MGF1):
             return (
-                self._oaep_mgf1_hash_supported(padding._mgf._algorithm) and
+                self._oaep_hash_supported(padding._mgf._algorithm) and
                 self._oaep_hash_supported(padding._algorithm)
             )
         else:

--- a/src/cryptography/hazmat/backends/openssl/backend.py
+++ b/src/cryptography/hazmat/backends/openssl/backend.py
@@ -603,21 +603,23 @@ class Backend(object):
             return isinstance(algorithm, hashes.SHA1)
 
     def _mgf1_hash_combination_supported(self, mgf_algo, algo):
-        if (self._mgf1_hash_supported(mgf_algo) and
-            self._mgf1_hash_supported(algo)):
+        if not self._mgf1_hash_supported(mgf_algo):
+            return False
 
-            # The same algorithm for both is always suppoted (SHA-1 or SHA-2)
-            if type(mgf_algo) is type(algo):
-                return True
-
-            # SHA-1 with SHA-2 combinations are not supported however:
-            if (isinstance(mgf_algo, hashes.SHA1) or
-                isinstance(algo, hashes.SHA1)):
-                return False
-
+        # The same algorithm for both is always suppoted (SHA-1 or SHA-2)
+        if type(mgf_algo) is type(algo):
             return True
 
-        return False
+        # The algorithms aren't the same so check support for the other one
+        if not self._mgf1_hash_supported(algo):
+            return False
+
+        # The algorithms are different; so neither can be SHA-1 as we
+        # don't support SHA-2 combinations with SHA-1.
+        if isinstance(mgf_algo, hashes.SHA1) or isinstance(algo, hashes.SHA1):
+            return False
+        else:
+            return True
 
     def rsa_padding_supported(self, padding):
         if isinstance(padding, PKCS1v15):

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -42,15 +42,37 @@ def _enc_dec_rsa(backend, key, data, padding):
     if isinstance(padding, PKCS1v15):
         padding_enum = backend._lib.RSA_PKCS1_PADDING
     elif isinstance(padding, OAEP):
+        padding_enum = backend._lib.RSA_PKCS1_OAEP_PADDING
+
+        if not isinstance(padding._mgf, MGF1):
+            raise UnsupportedAlgorithm(
+                "Only MGF1 is supported by this backend.",
+                _Reasons.UNSUPPORTED_MGF
+            )
+
+        if backend._lib.OpenSSL_version_num() < 0x10002001:
+            if not isinstance(padding._mgf._algorithm, hashes.SHA1):
+                raise UnsupportedAlgorithm(
+                    "OpenSSL < 1.0.2 only supports SHA1 inside MGF1 when "
+                    "using OAEP.",
+                    _Reasons.UNSUPPORTED_HASH
+                )
+            if not isinstance(padding._algorithm, hashes.SHA1):
+                raise UnsupportedAlgorithm(
+                    "OpenSSL < 1.0.2 only supports SHA1 when using OAEP.",
+                    _Reasons.UNSUPPORTED_HASH
+                )
+
         if not backend.rsa_padding_supported(padding):
             raise UnsupportedAlgorithm(
                 "This combination of padding and hash algorithm is not "
-                "supported by this backend.", _Reasons.UNSUPPORTED_PADDING
+                "supported by this backend.",
+                _Reasons.UNSUPPORTED_PADDING
             )
-        padding_enum = backend._lib.RSA_PKCS1_OAEP_PADDING
 
         if padding._label is not None and padding._label != b"":
             raise ValueError("This backend does not support OAEP labels.")
+
     else:
         raise UnsupportedAlgorithm(
             "{0} is not supported by this backend.".format(

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -208,7 +208,7 @@ class _RSASignatureContext(object):
                 raise ValueError("Digest too large for key size. Use a larger "
                                  "key.")
 
-            if not self._backend._mgf1_hash_supported(padding._mgf._algorithm):
+            if not self._backend._pss_mgf1_hash_supported(padding._mgf._algorithm):
                 raise UnsupportedAlgorithm(
                     "When OpenSSL is older than 1.0.1 then only SHA1 is "
                     "supported with MGF1.",
@@ -401,7 +401,7 @@ class _RSAVerificationContext(object):
                     "correct key and digest algorithm."
                 )
 
-            if not self._backend._mgf1_hash_supported(padding._mgf._algorithm):
+            if not self._backend._pss_mgf1_hash_supported(padding._mgf._algorithm):
                 raise UnsupportedAlgorithm(
                     "When OpenSSL is older than 1.0.1 then only SHA1 is "
                     "supported with MGF1.",

--- a/src/cryptography/hazmat/backends/openssl/rsa.py
+++ b/src/cryptography/hazmat/backends/openssl/rsa.py
@@ -42,34 +42,15 @@ def _enc_dec_rsa(backend, key, data, padding):
     if isinstance(padding, PKCS1v15):
         padding_enum = backend._lib.RSA_PKCS1_PADDING
     elif isinstance(padding, OAEP):
+        if not backend.rsa_padding_supported(padding):
+            raise UnsupportedAlgorithm(
+                "This combination of padding and hash algorithm is not "
+                "supported by this backend.", _Reasons.UNSUPPORTED_PADDING
+            )
         padding_enum = backend._lib.RSA_PKCS1_OAEP_PADDING
-        if not isinstance(padding._mgf, MGF1):
-            raise UnsupportedAlgorithm(
-                "Only MGF1 is supported by this backend.",
-                _Reasons.UNSUPPORTED_MGF
-            )
-
-        if (
-            not isinstance(padding._mgf._algorithm, hashes.SHA1) and
-            backend._lib.OpenSSL_version_num() < 0x10002001
-        ):
-            raise UnsupportedAlgorithm(
-                "OpenSSL < 1.0.2 only supports SHA1 inside MGF1 when "
-                "using OAEP.",
-                _Reasons.UNSUPPORTED_HASH
-            )
 
         if padding._label is not None and padding._label != b"":
             raise ValueError("This backend does not support OAEP labels.")
-
-        if (
-            not isinstance(padding._algorithm, hashes.SHA1) and
-            backend._lib.OpenSSL_version_num() < 0x10002001
-        ):
-            raise UnsupportedAlgorithm(
-                "OpenSSL < 1.0.2 only supports SHA1 when using OAEP.",
-                _Reasons.UNSUPPORTED_HASH
-            )
     else:
         raise UnsupportedAlgorithm(
             "{0} is not supported by this backend.".format(

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -403,6 +403,38 @@ class TestOpenSSLRSA(object):
                 ),
             ) is True
 
+    def test_rsa_padding_unsupported_oaep_combo_sha1_sha2(self):
+        hashalgs = (
+            hashes.SHA224(),
+            hashes.SHA256(),
+            hashes.SHA384(),
+            hashes.SHA512()
+        )
+        for hash_alg in hashalgs:
+            assert backend.rsa_padding_supported(
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
+                    algorithm=hash_alg,
+                    label=None
+                ),
+            ) is False
+
+    def test_rsa_padding_unsupported_oaep_combo_sha2_sha1(self):
+        hashalgs = (
+            hashes.SHA224(),
+            hashes.SHA256(),
+            hashes.SHA384(),
+            hashes.SHA512()
+        )
+        for hash_alg in hashalgs:
+            assert backend.rsa_padding_supported(
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hash_alg),
+                    algorithm=hashes.SHA1(),
+                    label=None
+                ),
+            ) is False
+
     def test_rsa_padding_unsupported_oaep_ripemd160_sha1(self):
         assert backend.rsa_padding_supported(
             padding.OAEP(

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import itertools
 
 import pytest
 
@@ -382,6 +383,44 @@ class TestOpenSSLRSA(object):
             ),
         ) is True
 
+    @pytest.mark.skipif(
+        backend._lib.OPENSSL_VERSION_NUMBER < 0x10002001,
+        reason="Requires OpenSSL >= 1.0.2"
+    )
+    def test_rsa_padding_supported_oaep_sha2_combinations(self):
+        hashalgs = (
+            hashes.SHA224(),
+            hashes.SHA256(),
+            hashes.SHA384(),
+            hashes.SHA512()
+        )
+        for hash_a, hash_b in itertools.product(hashalgs, hashalgs):
+            assert backend.rsa_padding_supported(
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hash_a),
+                    algorithm=hash_b,
+                    label=None
+                ),
+            ) is True
+
+    def test_rsa_padding_unsupported_oaep_ripemd160_sha1(self):
+        assert backend.rsa_padding_supported(
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.RIPEMD160()),
+                algorithm=hashes.SHA1(),
+                label=None
+            ),
+        ) is False
+
+    def test_rsa_padding_unsupported_oaep_sha1_ripemd160(self):
+        assert backend.rsa_padding_supported(
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA1()),
+                algorithm=hashes.RIPEMD160(),
+                label=None
+            ),
+        ) is False
+
     def test_rsa_padding_unsupported_mgf(self):
         assert backend.rsa_padding_supported(
             padding.OAEP(
@@ -423,6 +462,30 @@ class TestOpenSSLRSA(object):
                 padding.OAEP(
                     mgf=padding.MGF1(algorithm=hashes.SHA1()),
                     algorithm=hashes.SHA256(),
+                    label=None
+                )
+            )
+
+    def test_unsupported_mgf1_hash_algorithm_ripemd160_decrypt(self):
+        private_key = RSA_KEY_512.private_key(backend)
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
+            private_key.decrypt(
+                b"0" * 64,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.RIPEMD160()),
+                    algorithm=hashes.RIPEMD160(),
+                    label=None
+                )
+            )
+
+    def test_unsupported_mgf1_hash_algorithm_whirlpool_decrypt(self):
+        private_key = RSA_KEY_512.private_key(backend)
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
+            private_key.decrypt(
+                b"0" * 64,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.Whirlpool()),
+                    algorithm=hashes.Whirlpool(),
                     label=None
                 )
             )

--- a/tests/hazmat/backends/test_openssl.py
+++ b/tests/hazmat/backends/test_openssl.py
@@ -389,6 +389,7 @@ class TestOpenSSLRSA(object):
     )
     def test_rsa_padding_supported_oaep_sha2_combinations(self):
         hashalgs = (
+            hashes.SHA1(),
             hashes.SHA224(),
             hashes.SHA256(),
             hashes.SHA384(),
@@ -402,38 +403,6 @@ class TestOpenSSLRSA(object):
                     label=None
                 ),
             ) is True
-
-    def test_rsa_padding_unsupported_oaep_combo_sha1_sha2(self):
-        hashalgs = (
-            hashes.SHA224(),
-            hashes.SHA256(),
-            hashes.SHA384(),
-            hashes.SHA512()
-        )
-        for hash_alg in hashalgs:
-            assert backend.rsa_padding_supported(
-                padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hashes.SHA1()),
-                    algorithm=hash_alg,
-                    label=None
-                ),
-            ) is False
-
-    def test_rsa_padding_unsupported_oaep_combo_sha2_sha1(self):
-        hashalgs = (
-            hashes.SHA224(),
-            hashes.SHA256(),
-            hashes.SHA384(),
-            hashes.SHA512()
-        )
-        for hash_alg in hashalgs:
-            assert backend.rsa_padding_supported(
-                padding.OAEP(
-                    mgf=padding.MGF1(algorithm=hash_alg),
-                    algorithm=hashes.SHA1(),
-                    label=None
-                ),
-            ) is False
 
     def test_rsa_padding_unsupported_oaep_ripemd160_sha1(self):
         assert backend.rsa_padding_supported(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1369,7 +1369,7 @@ class TestRSADecryption(object):
 
     def test_unsupported_oaep_mgf(self, backend):
         private_key = RSA_KEY_512.private_key(backend)
-        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_MGF):
             private_key.decrypt(
                 b"0" * 64,
                 padding.OAEP(
@@ -1488,7 +1488,7 @@ class TestRSAEncryption(object):
         private_key = RSA_KEY_512.private_key(backend)
         public_key = private_key.public_key()
 
-        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_MGF):
             public_key.encrypt(
                 b"ciphertext",
                 padding.OAEP(

--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1369,7 +1369,7 @@ class TestRSADecryption(object):
 
     def test_unsupported_oaep_mgf(self, backend):
         private_key = RSA_KEY_512.private_key(backend)
-        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_MGF):
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
             private_key.decrypt(
                 b"0" * 64,
                 padding.OAEP(
@@ -1488,7 +1488,7 @@ class TestRSAEncryption(object):
         private_key = RSA_KEY_512.private_key(backend)
         public_key = private_key.public_key()
 
-        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_MGF):
+        with raises_unsupported_algorithm(_Reasons.UNSUPPORTED_PADDING):
             public_key.encrypt(
                 b"ciphertext",
                 padding.OAEP(


### PR DESCRIPTION
Raising this as WIP, want your thoughts on this approach. I've updated the openssl backend to limit the hashes allowed with RSA-OAEP depending on the OpenSSL version to those verified with test vectors. 

Doing this made some of the code in rsa.py a duplicate of the backend.py so I've removed the duplicate checks, however it does mean the errors are less verbose when an invalid combination is given. Advantage being only one set of checks need to be maintained and two areas of code don't need to be synchronised manually when changing.

What do you think? 