### PR TITLE
Add roundtrip encrypt/decrypt test for RSA-OAEP with SHA1 & SHA2 hash combinations

### DIFF
--- a/tests/hazmat/primitives/test_rsa.py
+++ b/tests/hazmat/primitives/test_rsa.py
@@ -1435,6 +1435,9 @@ class TestRSAEncryption(object):
         ], repeat=2)
     )
     def test_rsa_encrypt_oaep_sha2(self, hash_a, hash_b, backend):
+        if isinstance(hash_a, hashes.SHA1) and isinstance(hash_b, hashes.SHA1):
+            return  # Skip SHA-1 with SHA-1, this is checked by other tests
+
         pad = padding.OAEP(
             mgf=padding.MGF1(algorithm=hash_a),
             algorithm=hash_b,


### PR DESCRIPTION
First pass of adding roundtrip tests. Used the pytest parameterise to inject the combinations. The    pytest.mark.supported only checks for SHA-256 with SHA-512 to prove a SHA-2 combination works, is that acceptable? If not I'd probably think about a different approach.

I've used RSA_KEY_2048 for the key data, where the test_rsa_encrypt_oaep tests above try different combinations of key, should this also extend to more key sizes?